### PR TITLE
feat: symbolic link support

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,13 +40,15 @@ module.exports = function (file, opts) {
             firstFile = file;
         }
 
-        // Add to archive
-        if (file.isNull()) { // directories or file with empty .contents field
-            if (file.relative.length) {
-                archive.file(file.path, {name: file.relative});
+        // file.relative is an empty string on the base directory.
+        if (file.relative) {
+            if (file.isDirectory()) {
+                archive.append(null, {name: file.relative, type: "directory"});
+            } else if (file.isSymbolic()) {
+                archive.symlink(file.relative, file.symlink);
+            } else {
+                archive.append(file.contents, {name: file.relative, type: "file"});
             }
-        } else {
-            archive.append(file.contents, {name: file.relative});
         }
 
         cb();

--- a/test/fixtures/symbolic-link.txt
+++ b/test/fixtures/symbolic-link.txt
@@ -1,0 +1,1 @@
+fixture.txt

--- a/test/index.js
+++ b/test/index.js
@@ -87,9 +87,14 @@ describe('gulp-archiver', function() {
             // unzip
             .pipe(unzip())
             // check unzipped result
-            .pipe(assert.length(4))
+            .pipe(assert.length(5))
             .pipe(assert.nth(0,function(file) {
                 const path = 'fixture.txt';
+                file.path.should.eql(path);
+                file.contents.toString().should.eql(fs.readFileSync(fixtures(path), {encoding: 'utf8'}));
+            }))
+            .pipe(assert.nth(1,function(file) {
+                const path = 'symbolic-link.txt';
                 file.path.should.eql(path);
                 file.contents.toString().should.eql(fs.readFileSync(fixtures(path), {encoding: 'utf8'}));
             }))
@@ -125,9 +130,52 @@ describe('gulp-archiver', function() {
             // unzip
             .pipe(unzip())
             // check unzipped result
-            .pipe(assert.length(4))
+            .pipe(assert.length(5))
             .pipe(assert.nth(0,function(file) {
                 const path = 'fixture.txt';
+                file.path.should.eql(path);
+                file.contents.toString().should.eql(fs.readFileSync(fixtures(path), {encoding: 'utf8'}));
+            }))
+            .pipe(assert.nth(1,function(file) {
+                const path = 'directory/file0.txt';
+                file.path.should.eql(path);
+                file.contents.toString().should.eql(fs.readFileSync(fixtures(path), {encoding: 'utf8'}));
+            }))
+            .pipe(assert.nth(2,function(file) {
+                const path = 'directory/dir0/file1.txt';
+                file.path.should.eql(path);
+                file.contents.toString().should.eql(fs.readFileSync(fixtures(path), {encoding: 'utf8'}));
+            }))
+            .pipe(assert.nth(3,function(file) {
+                const path = 'directory/dir0/dir1/file2.txt';
+                file.path.should.eql(path);
+                file.contents.toString().should.eql(fs.readFileSync(fixtures(path), {encoding: 'utf8'}));
+            }))
+            // ok
+            .pipe(assert.end(done));
+    });
+
+    it('should archive directories with resolveSymlinks: false', function(done) {
+        this.timeout(0);
+
+        gulp.src(fixtures('**'), {resolveSymlinks: false})
+            .pipe(archive('test.zip'))
+            // check archive created correct
+            .pipe(assert.length(1))
+            .pipe(assert.first(function(destFile) {
+                destFile.path.should.eql(__dirname + '/fixtures/test.zip');
+            }))
+            // unzip
+            .pipe(unzip())
+            // check unzipped result
+            .pipe(assert.length(5))
+            .pipe(assert.nth(0,function(file) {
+                const path = 'fixture.txt';
+                file.path.should.eql(path);
+                file.contents.toString().should.eql(fs.readFileSync(fixtures(path), {encoding: 'utf8'}));
+            }))
+            .pipe(assert.nth(1,function(file) {
+                const path = 'symbolic-link.txt';
                 file.path.should.eql(path);
                 file.contents.toString().should.eql(fs.readFileSync(fixtures(path), {encoding: 'utf8'}));
             }))


### PR DESCRIPTION
Inspiration from:
* https://github.com/serverless-heaven/serverless-webpack/pull/485/files
* https://github.com/serverless-heaven/serverless-webpack/compare/master...Loomly:add-symlink-support?expand=1

How do we assert that the `nth 1` file is a symbolic link?